### PR TITLE
Fixed yaml spec to support EKS/k8s version 1.16

### DIFF
--- a/cluster_configs/aws-node.tpl.yaml
+++ b/cluster_configs/aws-node.tpl.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
@@ -99,7 +99,6 @@ spec:
           path: /var/run/docker.sock
           type: ""
         name: dockersock
-  templateGeneration: 1
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/cluster_configs/calico.tpl.yaml
+++ b/cluster_configs/calico.tpl.yaml
@@ -755,7 +755,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.8.1
+          image: calico/kube-controllers:v3.10.1
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/cluster_configs/dns.tpl.yaml
+++ b/cluster_configs/dns.tpl.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
@@ -125,13 +125,16 @@ spec:
           name: coredns
         name: config-volume
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations: {}
   name: external-dns
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: external-dns
   strategy:
     type: Recreate
   template:

--- a/cluster_configs/external-dns.tpl.yaml
+++ b/cluster_configs/external-dns.tpl.yaml
@@ -39,12 +39,15 @@ subjects:
   name: external-dns
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: external-dns
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: external-dns
   strategy:
     type: Recreate
   template:

--- a/cluster_configs/genie.tpl.yaml
+++ b/cluster_configs/genie.tpl.yaml
@@ -107,7 +107,7 @@ data:
 ---
 # Install CNI-Genie plugin on each slave node.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: genie-plugin
   namespace: kube-system
@@ -171,12 +171,15 @@ spec:
 ---
 # Genie network admission controller daemonset configuration
 # Genie network admission controller pods will run only in master nodes
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: genie-network-admission-controller
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      role: genie-network-admission-controller
   template:
     metadata:
       labels:

--- a/cluster_configs/heapster.tpl.yaml
+++ b/cluster_configs/heapster.tpl.yaml
@@ -4,13 +4,17 @@ metadata:
   name: heapster
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster
   namespace: kube-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: heapster
   template:
     metadata:
       labels:

--- a/cluster_configs/influxdb.tpl.yaml
+++ b/cluster_configs/influxdb.tpl.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: monitoring-influxdb
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      task: monitoring
+      k8s-app: influxdb
   replicas: 1
   template:
     metadata:

--- a/cluster_configs/metrics-server.tpl.yaml
+++ b/cluster_configs/metrics-server.tpl.yaml
@@ -58,7 +58,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server

--- a/cluster_configs/sealed-secrets-controller.tpl.yaml
+++ b/cluster_configs/sealed-secrets-controller.tpl.yaml
@@ -5,12 +5,15 @@ metadata:
   name: sealed-secrets-controller
   namespace: kube-system
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sealed-secrets-controller
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      name: sealed-secrets-controller
   template:
     metadata:
       labels:


### PR DESCRIPTION
Changes to the deployment and daemonset spec require the API spec to
change from `extension` to `app`. Also fixed pod spec selector parameter
as its now required.