### PR TITLE
Added variable to set External DNS policy option

### DIFF
--- a/cluster_configs/external-dns.tpl.yaml
+++ b/cluster_configs/external-dns.tpl.yaml
@@ -65,7 +65,7 @@ spec:
         # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
         ${domain_filters}
         - --provider=aws
-        - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+        - --policy=${policy_mode} # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
         - --aws-zone-type=${domain_type} # only look at public hosted zones (valid values are public, private or no value for both)
         - --registry=txt
         - --txt-owner-id=my-identifier

--- a/provision_external_dns.tf
+++ b/provision_external_dns.tf
@@ -12,6 +12,7 @@ module "provision_external_dns" {
       var.external_dns_domain_filters,
     )}" : ""
     domain_type = var.external_dns_type
+    policy_mode = var.external_dns_policy_mode
   }
 
   module_depends_on = [module.wait_for_eks.command]

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ module "eks" {
 
   external_dns_domain_filters = ["<route 53 domain>"]
   external_dns_type = "<internal|external>" or "" for auto-detect (default)
+  external_dns_policy_mode = "upsert-only" (default)
 
   nodes_key_name = "eks"
 

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,11 @@ variable "external_dns_type" {
   default     = ""
 }
 
+variable "external_dns_policy_mode" {
+  description = "Set the External DNS --policy option"
+  default     = "upsert-only"
+}
+
 variable "allow_ssh" {
   description = "If SSH should be allowed into the worker nodes security group"
   default     = "true"


### PR DESCRIPTION
Added a variable which gets passed to the External DNS resources to
allow the `--policy` option to be set, allowing the pod to delete DNS
entries when an ingress resource is removed. The default option is to
write and update only, not delete.