### PR TITLE
Added option to set the externalDNS policy mode

### DIFF
--- a/cluster_configs/external-dns.tpl.yaml
+++ b/cluster_configs/external-dns.tpl.yaml
@@ -58,14 +58,14 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.7.1
+        image: k8s.gcr.io/external-dns/external-dns:v0.7.3
         args:
         - --source=service
         - --source=ingress
         # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
         ${domain_filters}
         - --provider=aws
-        - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+        - --policy=${policy_mode}
         - --aws-zone-type=${domain_type} # only look at public hosted zones (valid values are public, private or no value for both)
         - --registry=txt
         - --txt-owner-id=my-identifier

--- a/provision_external_dns.tf
+++ b/provision_external_dns.tf
@@ -10,6 +10,7 @@ data "kubectl_path_documents" "external_dns_resources" {
   vars = {
     domain_filters = local.external_dns_domain_filters
     domain_type    = var.external_dns_type
+    policy_mode    = var.external_policy_mode
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ module "eks" {
 
   external_dns_domain_filters = ["<route 53 domain>"]
   external_dns_type = "<internal|external>" or "" for auto-detect (default)
+  external_policy_mode = "<upsert-only|sync>" or omitted for default
 
   nodes_key_name = "eks"
 

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,11 @@ variable "external_dns_type" {
   default     = ""
 }
 
+variable "external_policy_mode" {
+  description = "The External DNS policy mode to pass to External DNS --policy option"
+  default     = "upsert-only"
+}
+
 variable "allow_ssh" {
   description = "If SSH should be allowed into the worker nodes security group"
   default     = "true"


### PR DESCRIPTION
Allow users to set the ExternalDNS --policy option to allow the ability
to override the default option should the user want ExternalDNS to
remove stale records. The default option is to only add records, and not
delete.